### PR TITLE
Fw lite mva 10 3 1

### DIFF
--- a/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2.h
@@ -59,12 +59,6 @@ class ElectronMVAEstimatorRun2 : public AnyMVAEstimatorRun2Base {
   // Calculation of the MVA value
   float mvaValue( const reco::Candidate* candidate, std::vector<float> const& auxVariables, int &iCategory) const override;
 
-  // Also implemented in AnyMVAEstimatorRun2Base, but reimplemented here for fwlite to use
-  float mvaValue( const reco::Candidate* candidate, std::vector<float> const& auxVariables) const {
-      int iCategory;
-      return mvaValue(candidate, auxVariables, iCategory);
-  };
-
   int findCategory( const reco::Candidate* candidate) const override;
 
  private:

--- a/RecoEgamma/ElectronIdentification/python/FWLite.py
+++ b/RecoEgamma/ElectronIdentification/python/FWLite.py
@@ -1,4 +1,5 @@
 import ROOT
+import ctypes
 
 # Python wrappers around the Electron MVAs.
 # Usage example in RecoEgamma/ElectronIdentification/test
@@ -29,7 +30,10 @@ class ElectronMVAID:
                 self.variablesFile, categoryCutStrings, self.xmls, self._debug)
             self._init = True
         extra_vars = self.estimator.getExtraVars(ele, convs, beam_spot, rho[0])
-        return self.estimator.mvaValue(ele, extra_vars)
+        category = ctypes.c_int(0)
+        mva = self.estimator.mvaValue(ele, extra_vars, category)
+        return mva, category
+
 
 # Import information needed to construct the e/gamma MVAs
 

--- a/RecoEgamma/ElectronIdentification/python/FWLite.py
+++ b/RecoEgamma/ElectronIdentification/python/FWLite.py
@@ -1,5 +1,6 @@
 import ROOT
 import ctypes
+import pprint
 
 # Python wrappers around the Electron MVAs.
 # Usage example in RecoEgamma/ElectronIdentification/test
@@ -19,6 +20,27 @@ class ElectronMVAID:
         self._debug = debug
 
     def __call__(self, ele, convs, beam_spot, rho, debug=False):
+        '''returns a tuple mva_value, category 
+        ele: a reco::GsfElectron
+        convs: conversions
+        beam_spot: beam spot
+        rho: energy density in the event
+        debug: enable debugging mode. 
+
+        example: 
+        
+            event.getByLabel(('slimmedElectrons'),                 ele_handle)
+            event.getByLabel(('fixedGridRhoFastjetAll'),           rho_handle)
+            event.getByLabel(('reducedEgamma:reducedConversions'), conv_handle)
+            event.getByLabel(('offlineBeamSpot'),                  bs_handle)
+            
+            electrons = ele_handle.product()
+            convs     = conv_handle.product()
+            beam_spot = bs_handle.product()
+            rho       = rho_handle.product()
+
+            mva, category = electron_mva_id(electron[0], convs, beam_spot, rho)
+        '''
         if not self._init:
             print('Initializing ' + self.name + self.tag)
             ROOT.gSystem.Load("libRecoEgammaElectronIdentification")
@@ -32,7 +54,33 @@ class ElectronMVAID:
         extra_vars = self.estimator.getExtraVars(ele, convs, beam_spot, rho[0])
         category = ctypes.c_int(0)
         mva = self.estimator.mvaValue(ele, extra_vars, category)
-        return mva, category
+        return mva, category.value
+
+
+class WorkingPoints(object):
+    '''Working Points. Keeps track of the cuts associated to a given flavour of the MVA ID 
+    for each working point and allows to test the working points'''
+
+    def __init__(self, name, tag, working_points):
+        self.name = name 
+        self.tag = tag
+        self.working_points = self._reformat_cut_definitions(working_points)
+
+    def _reformat_cut_definitions(self, working_points):
+        new_definitions = dict()
+        for wpname, definitions in working_points.iteritems():
+            new_definitions[wpname] = dict()
+            for name, cut in definitions.cuts.iteritems():
+                categ_id = int(name.lstrip('cutCategory'))
+                cut = cut.replace('pt','x')
+                formula = ROOT.TFormula('_'.join([self.name, wpname, name]), cut)
+                new_definitions[wpname][categ_id] = formula
+        return new_definitions
+
+    def passed(self, ele, mva, category, wp):
+        '''return true if ele passes wp'''
+        threshold = self.working_points[wp][category].Eval(ele.pt())
+        return mva > threshold  # or should it be >= ? 
 
 
 # Import information needed to construct the e/gamma MVAs
@@ -41,18 +89,25 @@ from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_tools import
 
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V2_cff import mvaWeightFiles as Fall17_iso_V2_weightFiles
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff import mvaWeightFiles as Fall17_noIso_V2_weightFiles
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff import workingPoints as Fall17_noIso_V2_workingPoints
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff import mvaSpring16WeightFiles_V1 as mvaSpring16GPWeightFiles_V1
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff import mvaSpring16WeightFiles_V1 as mvaSpring16HZZWeightFiles_V1
 
 # Dictionary with the relecant e/gmma MVAs
 
-ElectronMVAs = {
-        "Fall17IsoV2"   : ElectronMVAID("ElectronMVAEstimatorRun2","Fall17IsoV2",
-                                      EleMVA_6CategoriesCuts, Fall17_iso_V2_weightFiles, mvaVariablesFile),
-        "Fall17NoIsoV2" : ElectronMVAID("ElectronMVAEstimatorRun2","Fall17NoIsoV2",
-                                      EleMVA_6CategoriesCuts, Fall17_noIso_V2_weightFiles, mvaVariablesFile),
-        "Spring16HZZV1" : ElectronMVAID("ElectronMVAEstimatorRun2","Spring16HZZV1",
-                                      EleMVA_6CategoriesCuts, mvaSpring16HZZWeightFiles_V1, mvaVariablesFile),
-        "Spring16V1"    : ElectronMVAID("ElectronMVAEstimatorRun2","Spring16GeneralPurposeV1",
-                                      EleMVA_3CategoriesCuts, mvaSpring16GPWeightFiles_V1, mvaVariablesFile),
-}
+electron_mvas = {
+    "Fall17IsoV2"   : ElectronMVAID("ElectronMVAEstimatorRun2","Fall17IsoV2",
+                                    EleMVA_6CategoriesCuts, Fall17_iso_V2_weightFiles, mvaVariablesFile),
+    "Fall17NoIsoV2" : ElectronMVAID("ElectronMVAEstimatorRun2","Fall17NoIsoV2",
+                                    EleMVA_6CategoriesCuts, Fall17_noIso_V2_weightFiles, mvaVariablesFile),
+    "Spring16HZZV1" : ElectronMVAID("ElectronMVAEstimatorRun2","Spring16HZZV1",
+                                    EleMVA_6CategoriesCuts, mvaSpring16HZZWeightFiles_V1, mvaVariablesFile),
+    "Spring16V1"    : ElectronMVAID("ElectronMVAEstimatorRun2","Spring16GeneralPurposeV1",
+                                    EleMVA_3CategoriesCuts, mvaSpring16GPWeightFiles_V1, mvaVariablesFile),
+    }
+
+working_points = {
+    "Fall17NoIsoV2" : WorkingPoints("ElectronMVAEstimatorRun2","Fall17NoIsoV2",
+                                    Fall17_noIso_V2_workingPoints),
+
+    }

--- a/RecoEgamma/ElectronIdentification/python/FWLite.py
+++ b/RecoEgamma/ElectronIdentification/python/FWLite.py
@@ -88,10 +88,13 @@ class WorkingPoints(object):
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_tools import EleMVA_6CategoriesCuts, mvaVariablesFile, EleMVA_3CategoriesCuts
 
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V2_cff import mvaWeightFiles as Fall17_iso_V2_weightFiles
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V2_cff import workingPoints as Fall17_iso_V2_workingPoints
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff import mvaWeightFiles as Fall17_noIso_V2_weightFiles
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff import workingPoints as Fall17_noIso_V2_workingPoints
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff import mvaSpring16WeightFiles_V1 as mvaSpring16GPWeightFiles_V1
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_GeneralPurpose_V1_cff import workingPoints as mvaSpring16GP_V1_workingPoints
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff import mvaSpring16WeightFiles_V1 as mvaSpring16HZZWeightFiles_V1
+from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring16_HZZ_V1_cff import workingPoints as mvaSpring16HZZ_V1_workingPoints
 
 # Dictionary with the relecant e/gmma MVAs
 
@@ -107,7 +110,13 @@ electron_mvas = {
     }
 
 working_points = {
+    "Fall17IsoV2" : WorkingPoints("ElectronMVAEstimatorRun2","Fall17IsoV2",
+                                    Fall17_iso_V2_workingPoints),
     "Fall17NoIsoV2" : WorkingPoints("ElectronMVAEstimatorRun2","Fall17NoIsoV2",
                                     Fall17_noIso_V2_workingPoints),
+    "Spring16HZZV1" : WorkingPoints("ElectronMVAEstimatorRun2","Spring16HZZV1",
+                                    mvaSpring16HZZ_V1_workingPoints),
+    "Spring16V1": WorkingPoints("ElectronMVAEstimatorRun2","Spring16GeneralPurposeV1",
+                                mvaSpring16GP_V1_workingPoints),
 
     }

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_iso_V2_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_iso_V2_cff.py
@@ -59,6 +59,13 @@ mvaEleID_Fall17_iso_V2_wp90_container = EleMVARaw_WP(
     )
 
 
+workingPoints = dict(
+    wpHZZ = mvaEleID_Fall17_iso_V2_wpHZZ_container,
+    wp80 = mvaEleID_Fall17_iso_V2_wp80_container,
+    wpLoose = mvaEleID_Fall17_iso_V2_wpLoose_container,
+    wp90 = mvaEleID_Fall17_iso_V2_wp90_container
+)
+
 mvaEleID_Fall17_iso_V2_producer_config = cms.PSet(
     mvaName             = cms.string(mvaClassName),
     mvaTag              = cms.string(mvaTag),

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_noIso_V2_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_noIso_V2_cff.py
@@ -48,6 +48,11 @@ mvaEleID_Fall17_noIso_V2_wp90_container = EleMVARaw_WP(
     cutCategory5 = "4.16921343208 - exp(-pt / 13.2017224621) * 9.00720913211", # EE_10
     )
 
+workingPoints = dict(
+    wp80 = mvaEleID_Fall17_noIso_V2_wp80_container,
+    wpLoose = mvaEleID_Fall17_noIso_V2_wpLoose_container,
+    wp90 = mvaEleID_Fall17_noIso_V2_wp90_container
+)
 
 mvaEleID_Fall17_noIso_V2_producer_config = cms.PSet(
     mvaName             = cms.string(mvaClassName),

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_GeneralPurpose_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_GeneralPurpose_V1_cff.py
@@ -45,7 +45,10 @@ MVA_WP80 = EleMVA_WP(
     cutCategory2 =  "0.758484721184", # EE
     )
 
-
+workingPoints = dict(
+    wp80 = MVA_WP80,
+    wp90 = MVA_WP90
+)
 
 #
 # Finally, set up VID configuration for all cuts

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_HZZ_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_HZZ_V1_cff.py
@@ -51,6 +51,10 @@ MVA_WPLoose = EleMVA_WP(
     cutCategory5 =  "-0.763"  # EE
     )
 
+workingPoints = dict(
+    wpLoose = MVA_WPLoose
+)
+
 
 #
 # Finally, set up VID configuration for all cuts

--- a/RecoEgamma/ElectronIdentification/test/test_eleid_fwlite.py
+++ b/RecoEgamma/ElectronIdentification/test/test_eleid_fwlite.py
@@ -30,13 +30,16 @@ for i,event in enumerate(events):
     beam_spot = bs_handle.product()
     rho       = rho_handle.product()
 
+    def test_mva(ele, mvaname, convs, beam_spot, rho):
+        mva, category = electron_mvas[mvaname](ele, convs, beam_spot, rho)
+        wps = working_points[mvaname]
+        print '{:<20}, electron, pt={:5.1f}, mva={:5.2f}, cat={:d}'.format(mvaname, ele.pt(), mva, category)
+        for wp in wps.working_points:
+            print '\t', wp, wps.passed(ele, mva, category, wp)
+
     for ele in electrons:
-        mva, category = electron_mvas["Fall17IsoV2"](ele, convs, beam_spot, rho)
-        print("Fall17IsoV2 = " + str(mva)), category
-        mva, category = electron_mvas["Fall17NoIsoV2"](ele, convs, beam_spot, rho)
-        passed = working_points['Fall17NoIsoV2'].passed(ele, mva, category, 'wp90')
-        print("Fall17NoIsoV2 = " + str(mva)), category, passed
-        mva, category = electron_mvas["Spring16HZZV1"](ele, convs, beam_spot, rho)
-        print("Spring16HZZV1 = " + str(mva)), category
-        mva, category  = electron_mvas["Spring16V1"](ele, convs, beam_spot, rho)
-        print("Spring16V1 = " + str(mva)), category
+        test_mva(ele, 'Fall17IsoV2', convs, beam_spot, rho)
+        test_mva(ele, 'Fall17NoIsoV2', convs, beam_spot, rho)
+        test_mva(ele, 'Spring16HZZV1', convs, beam_spot, rho)
+        test_mva(ele, 'Spring16V1', convs, beam_spot, rho)
+

--- a/RecoEgamma/ElectronIdentification/test/test_eleid_fwlite.py
+++ b/RecoEgamma/ElectronIdentification/test/test_eleid_fwlite.py
@@ -31,11 +31,11 @@ for i,event in enumerate(events):
     rho       = rho_handle.product()
 
     for ele in electrons:
-        mva = ElectronMVAs["Fall17IsoV2"](ele, convs, beam_spot, rho)
-        print("Fall17IsoV2 = " + str(mva))
-        mva = ElectronMVAs["Fall17NoIsoV2"](ele, convs, beam_spot, rho)
-        print("Fall17NoIsoV2 = " + str(mva))
-        mva = ElectronMVAs["Spring16HZZV1"](ele, convs, beam_spot, rho)
-        print("Spring16HZZV1 = " + str(mva))
-        mva = ElectronMVAs["Spring16V1"](ele, convs, beam_spot, rho)
-        print("Spring16V1 = " + str(mva))
+        mva, category = ElectronMVAs["Fall17IsoV2"](ele, convs, beam_spot, rho)
+        print("Fall17IsoV2 = " + str(mva)), category
+        mva, category = ElectronMVAs["Fall17NoIsoV2"](ele, convs, beam_spot, rho)
+        print("Fall17NoIsoV2 = " + str(mva)), category
+        mva, category = ElectronMVAs["Spring16HZZV1"](ele, convs, beam_spot, rho)
+        print("Spring16HZZV1 = " + str(mva)), category
+        mva, category  = ElectronMVAs["Spring16V1"](ele, convs, beam_spot, rho)
+        print("Spring16V1 = " + str(mva)), category

--- a/RecoEgamma/ElectronIdentification/test/test_eleid_fwlite.py
+++ b/RecoEgamma/ElectronIdentification/test/test_eleid_fwlite.py
@@ -1,4 +1,4 @@
-from RecoEgamma.ElectronIdentification.FWLite import ElectronMVAs
+from RecoEgamma.ElectronIdentification.FWLite import electron_mvas, working_points
 from DataFormats.FWLite import Events, Handle
 
 print('open input file...')
@@ -31,11 +31,12 @@ for i,event in enumerate(events):
     rho       = rho_handle.product()
 
     for ele in electrons:
-        mva, category = ElectronMVAs["Fall17IsoV2"](ele, convs, beam_spot, rho)
+        mva, category = electron_mvas["Fall17IsoV2"](ele, convs, beam_spot, rho)
         print("Fall17IsoV2 = " + str(mva)), category
-        mva, category = ElectronMVAs["Fall17NoIsoV2"](ele, convs, beam_spot, rho)
-        print("Fall17NoIsoV2 = " + str(mva)), category
-        mva, category = ElectronMVAs["Spring16HZZV1"](ele, convs, beam_spot, rho)
+        mva, category = electron_mvas["Fall17NoIsoV2"](ele, convs, beam_spot, rho)
+        passed = working_points['Fall17NoIsoV2'].passed(ele, mva, category, 'wp90')
+        print("Fall17NoIsoV2 = " + str(mva)), category, passed
+        mva, category = electron_mvas["Spring16HZZV1"](ele, convs, beam_spot, rho)
         print("Spring16HZZV1 = " + str(mva)), category
-        mva, category  = ElectronMVAs["Spring16V1"](ele, convs, beam_spot, rho)
+        mva, category  = electron_mvas["Spring16V1"](ele, convs, beam_spot, rho)
         print("Spring16V1 = " + str(mva)), category


### PR DESCRIPTION
Hi Jonas! 

To be able to apply the mva electron identification in python + FWLite, ones needs: 
- to expose the electron category in python
- an infrastructure to apply the correct cut to the mva output depending on the category. 

I've implemented this for the non iso v2 only for now. Could you please have a look and test? 
If you agree with that, I can implement this feature for the other electron ids. 
I also added some documentation.

Thank you! 
Colin 
